### PR TITLE
Fix TCP connection failure when attempting to use a remote host as TNC

### DIFF
--- a/TCP.c
+++ b/TCP.c
@@ -21,7 +21,7 @@ int open_tcp(char* ip, int port) {
     memset(&serv_addr, 0, sizeof(serv_addr)); 
     serv_addr.sin_family = AF_INET;
 
-    memcpy(server->h_addr, &serv_addr.sin_addr.s_addr, server->h_length);
+    memcpy(&serv_addr.sin_addr.s_addr, server->h_addr, server->h_length);
     serv_addr.sin_port = htons(port);
 
     if (connect(sockfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {


### PR DESCRIPTION
This PR fixes an issue where TCP connections to remote hosts were failing due to incorrect memory copying of the host address.

The bug was in the `open_tcp` function where the `memcpy` parameters were reversed:
```c
// Old (buggy) code:
memcpy(server->h_addr, &serv_addr.sin_addr.s_addr, server->h_length);

// New (fixed) code:
memcpy(&serv_addr.sin_addr.s_addr, server->h_addr, server->h_length);
```

The fix reverses the parameters so that:
- Source: `server->h_addr` (the resolved host address)
- Destination: `&serv_addr.sin_addr.s_addr` (the socket address structure)
- Length: `server->h_length` (unchanged)

This allows tncattach to properly connect to remote TNCs over TCP as intended.