### PR TITLE
Add IPv6 support (command-line and tuntap)

### DIFF
--- a/TAP.c
+++ b/TAP.c
@@ -351,7 +351,7 @@ int open_tap(void) {
                                     memset(&six_addr_itself, 0, sizeof(struct in6_addr));
                                     if(inet_pton(AF_INET6, ipv6_addr, &six_addr_itself) < 0)
                                     {
-                                        printf("Error parsing IPv6 address '%s'", ipv6_addr);
+                                        printf("Error parsing IPv6 address '%s'\n", ipv6_addr);
                                         close(dummySock);
                                         cleanup();
                                         exit(1);

--- a/TAP.c
+++ b/TAP.c
@@ -366,16 +366,6 @@ int open_tap(void) {
                                             exit(1);
                                         }
 
-                                        // Choose stratergy for generating link-local address
-                                        if(device_type == IF_TAP)                                
-                                        {
-
-                                        }
-                                        else
-                                        {
-
-                                        }
-                                        
                                         // Add user's requested address
                                         trySixSet(ifr.ifr_ifindex, six_addr_itself, prefixLen_l);
                                     }

--- a/TAP.c
+++ b/TAP.c
@@ -1,11 +1,7 @@
 #include "TAP.h"
 
 // Needed for in6_ifreq
-// #include <arpa/inet.h>
 #include <linux/ipv6.h>
-// #include <netinet/in.h>
-// #include <sys/ioctl.h>
-// #include <sys/socket.h>
 
 char tap_name[IFNAMSIZ];
 

--- a/TAP.c
+++ b/TAP.c
@@ -14,6 +14,7 @@ extern int device_type;
 extern char if_name[IFNAMSIZ];
 extern char* ipv4_addr;
 extern char* ipv6_addr;
+extern long ipv6_prefixLen;
 extern char* netmask;
 extern void cleanup();
 
@@ -259,23 +260,6 @@ int open_tap(void) {
                                         exit(1);
                                     }
 
-                                    char* ipPart = strtok(ipv6_addr, "/");
-                                    char* prefixPart_s = strtok(NULL, "/");
-                                    printf("ip part: %s\n", ipPart);
-
-                                    if(!prefixPart_s)
-                                    {
-                                        printf("No prefix length was provided\n"); // TODO: Move logic into arg parsing
-                                        close(inet6);
-                                        cleanup();
-                                        exit(1);
-                                    }
-                                    printf("prefix part: %s\n", prefixPart_s);
-
-                                    long prefixLen_l = strtol(prefixPart_s, NULL, 10); // TODO: Add handling here for errors (using errno)
-
-
-
                                     // Convert ASCII IPv6 address to ABI structure
                                     struct in6_addr six_addr_itself;
                                     memset(&six_addr_itself, 0, sizeof(struct in6_addr));
@@ -288,7 +272,7 @@ int open_tap(void) {
                                     }
 
                                     // Add user's requested address
-                                    trySixSet(ifr.ifr_ifindex, six_addr_itself, prefixLen_l);
+                                    trySixSet(ifr.ifr_ifindex, six_addr_itself, ipv6_prefixLen);
 
                                     close(inet6);
                                 }

--- a/TAP.c
+++ b/TAP.c
@@ -1,8 +1,5 @@
 #include "TAP.h"
 
-// Needed for in6_ifreq
-#include <linux/ipv6.h>
-
 char tap_name[IFNAMSIZ];
 
 extern bool verbose;

--- a/TAP.c
+++ b/TAP.c
@@ -43,6 +43,7 @@ struct in6_addr generateLinkLocal(char* interfaceName)
     if(dummySock < 0)
     {
         printf("Failed to open configuration socket in order to generate link-local address\n");
+        close(dummySock);
         exit(1);
     }
 
@@ -53,6 +54,7 @@ struct in6_addr generateLinkLocal(char* interfaceName)
     if(ioctl(dummySock, SIOCGIFHWADDR, &reqParams) < 0)
     {
         printf("Failed to fetch hardware address Failed to open configuration socket in order to generate link-local address\n");
+        close(dummySock);
         exit(1);
     }
 
@@ -66,8 +68,6 @@ void trySixSet
     int prefixLen
 )
 {
-    printf("Strat 1, setting...\n");
-
     char ip_str[INET6_ADDRSTRLEN+1];
     inet_ntop(AF_INET6, &address, ip_str, INET6_ADDRSTRLEN+1);
 
@@ -325,20 +325,12 @@ int open_tap(void) {
                                         exit(1);
                                     }
 
+                                    // Add link-local address
+                                    trySixSet(ifr.ifr_ifindex, generateLinkLocal(if_name), 64);
 
-                                    // printf("Using prefix length of '%d'\n", netmask);
-
-                                    // TODO: Add user's requested address
+                                    // Add user's requested address
                                     trySixSet(ifr.ifr_ifindex, six_addr_itself, prefixLen_l);
-                                    
-                                    trySixSet(ifr.ifr_ifindex, generateLinkLocal(ifr.ifr_ifindex), 64);
-                                    // six_addr_itself.s6_addr[0] = 0xfe;
-                                    // six_addr_itself.s6_addr[1] = 0x80;
-                                    // six_addr_itself.s6_addr[15] = 1;
 
-                                    
-
-                                    // TODO: 
                                     // FIXME: Allow the ipv6 to be empty and just do link-local
 
                                     printf("IPv6 settings SHOULD be done now\n");

--- a/TAP.c
+++ b/TAP.c
@@ -40,7 +40,7 @@ void localRand(struct in6_addr* ll_a)
 struct in6_addr generateLinkLocal(char* interfaceName)
 {
     time_t t = time(NULL);
-    srand(t); // TODO: FIXME, use time or something
+    srand(t);
 
     struct in6_addr ll_a;
     memset(&ll_a, 0, sizeof(struct in6_addr));

--- a/TAP.c
+++ b/TAP.c
@@ -252,7 +252,7 @@ int open_tap(void) {
 
                                     if(!prefixPart_s)
                                     {
-                                        perror("No prefix length was provided"); // TODO: Move logic into arg parsing
+                                        printf("No prefix length was provided\n"); // TODO: Move logic into arg parsing
                                         close(inet6);
                                         cleanup();
                                         exit(1);

--- a/TAP.c
+++ b/TAP.c
@@ -6,7 +6,7 @@ extern bool verbose;
 extern bool noipv6;
 extern bool set_ipv4;
 extern bool set_ipv6;
-extern bool link_local_v6;
+extern bool set_linklocal;
 extern bool set_netmask;
 extern bool noup;
 extern int mtu;
@@ -241,7 +241,7 @@ int open_tap(void) {
                                     }
                                 }
 
-                                if(set_ipv6)
+                                if(set_ipv6 || set_linklocal)
                                 {
                                     // Firstly, obtain the interface index by `ifr_name`
                                     int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
@@ -259,6 +259,18 @@ int open_tap(void) {
                                         cleanup();
                                         exit(1);
                                     }
+
+																		// if link-local was NOT requested and interface
+																		// has been up'd -> then kernel would have added
+																		// a link-local already, this removes it
+                                    if(!set_linklocal & !noup)
+                                    {
+                                    		// TODO: Get all addresses that start with fe80
+                                    }
+                                    // Else it could have been no-up; hence you will have to remove
+                                    // the link-local yourself
+                                    // Other else is link-local was requested, then we don't care (whether
+                                    // up'd or not as it will inevitably be added by the kernel)
 
                                     // Convert ASCII IPv6 address to ABI structure
                                     struct in6_addr six_addr_itself;

--- a/TAP.c
+++ b/TAP.c
@@ -13,6 +13,7 @@ extern bool verbose;
 extern bool noipv6;
 extern bool set_ipv4;
 extern bool set_ipv6;
+extern bool link_local_v6;
 extern bool set_netmask;
 extern bool noup;
 extern int mtu;
@@ -99,30 +100,38 @@ void trySixSet
         interfaceIndex
     );
 
+    if(mtu < 1280)
+    {
+        printf("MTU must be 1280 bytes or more for IPv6\n");
+        cleanup();
+        exit(1);
+    }
+
 	int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
 
-
-
-	
 	struct in6_ifreq paramReq;
 	memset(&paramReq, 0, sizeof(struct in6_ifreq));
 	paramReq.ifr6_ifindex = interfaceIndex;
- 	printf("paramReq.ifr6_ifindex: %d\n", paramReq.ifr6_ifindex);
  	paramReq.ifr6_prefixlen = prefixLen;
  	paramReq.ifr6_addr = address;
 
 	
-
+    // Try add the address
 	if(ioctl(dummySock, SIOCSIFADDR, &paramReq) < 0)
 	{
- 		// perror("Fokop");
- 		printf("Fokop\n");
+ 		printf
+        (
+            "There was an errror assigning address '%s/%d' to if_index %d\n",
+            ip_str,
+            prefixLen,
+            interfaceIndex
+        );
  		cleanup();
  		close(dummySock);
  		exit(1);
  	}
 
-    printf("Sucessfully applied IPv6 configuration");
+    printf("Address '%s/%d' added\n", ip_str, prefixLen);
 	close(dummySock);
 }
 
@@ -306,7 +315,7 @@ int open_tap(void) {
                                     }
                                 }
 
-                                if(set_ipv6) {
+                                if(set_ipv6 || link_local_v6) {
                                 	printf("TODO: Implement set ipv6\n");
 
                                     // Firstly, obtain the interface index by `ifr_name`
@@ -363,7 +372,7 @@ int open_tap(void) {
 
                                     // FIXME: Allow the ipv6 to be empty and just do link-local
 
-                                    printf("IPv6 settings SHOULD be done now\n");
+                                    printf("IPv6 configuration done\n");
                                 }
                             }
                         }

--- a/TAP.c
+++ b/TAP.c
@@ -97,9 +97,7 @@ int open_tap(void) {
             
             int inet = socket(AF_INET, SOCK_DGRAM, 0);
             if (inet == -1) {
-            	  char err[100];
-            		sprintf(err, "Could not open %s socket", set_ipv4 ? "AF_INET" : "AF_INET6");
-                perror(err);
+                perror("Could not open control socket");
                 cleanup();
                 exit(1);
             } else {

--- a/TAP.c
+++ b/TAP.c
@@ -317,13 +317,14 @@ int open_tap(void) {
                                         cleanup();
                                         exit(1);
                                     }
-                                    
+
                                     // Firstly, obtain the interface index by `ifr_name`
                                     int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
                                     if(ioctl(dummySock, SIOCGIFINDEX, &ifr) < 0)
                                     {
                                         printf("Could not get interface index for interface '%s'\n", ifr.ifr_name);
                                         close(dummySock);
+                                        cleanup();
                                         exit(1);
                                     }					
 
@@ -336,6 +337,7 @@ int open_tap(void) {
                                     {
                                         perror("No prefix length was provided"); // TODO: Move logic into arg parsing
                                         close(dummySock);
+                                        cleanup();
                                         exit(1);
                                     }
                                     printf("prefix part: %s\n", prefixPart_s);
@@ -351,6 +353,7 @@ int open_tap(void) {
                                     {
                                         printf("Error parsing IPv6 address '%s'", ipv6_addr);
                                         close(dummySock);
+                                        cleanup();
                                         exit(1);
                                     }
 

--- a/TAP.c
+++ b/TAP.c
@@ -100,14 +100,6 @@ void trySixSet
         interfaceIndex
     );
 
-    // linux IPv6 mtu check
-    if(mtu < 1280)
-    {
-        printf("MTU must be 1280 bytes or more for IPv6\n");
-        cleanup();
-        exit(1);
-    }
-
 	int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
 
 	struct in6_ifreq paramReq;
@@ -318,6 +310,14 @@ int open_tap(void) {
 
                                 if(set_ipv6 || link_local_v6)
                                 {
+                                    // linux IPv6 mtu check
+                                    if(mtu < 1280)
+                                    {
+                                        printf("MTU must be 1280 bytes or more for IPv6\n");
+                                        cleanup();
+                                        exit(1);
+                                    }
+                                    
                                     // Firstly, obtain the interface index by `ifr_name`
                                     int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
                                     if(ioctl(dummySock, SIOCGIFINDEX, &ifr) < 0)

--- a/TAP.c
+++ b/TAP.c
@@ -64,8 +64,6 @@ void trySixSet
 	close(inet6);
 }
 
-#include<string.h>
-
 int open_tap(void) {
     struct ifreq ifr;
     int fd = open("/dev/net/tun", O_RDWR);

--- a/TAP.c
+++ b/TAP.c
@@ -37,6 +37,12 @@ void trySixSet
     );
 
 	int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
+    if(inet6 < 0)
+    {
+        printf("Error opening control socket for adding IPv6 address to interface\n");
+        cleanup();
+        exit(1);
+    }
 
 	struct in6_ifreq paramReq;
 	memset(&paramReq, 0, sizeof(struct in6_ifreq));

--- a/TAP.c
+++ b/TAP.c
@@ -37,7 +37,7 @@ void trySixSet
         interfaceIndex
     );
 
-	int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
+    int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
     if(inet6 < 0)
     {
         printf("Error opening control socket for adding IPv6 address to interface\n");
@@ -45,30 +45,30 @@ void trySixSet
         exit(1);
     }
 
-	struct in6_ifreq paramReq;
-	memset(&paramReq, 0, sizeof(struct in6_ifreq));
-	paramReq.ifr6_ifindex = interfaceIndex;
- 	paramReq.ifr6_prefixlen = prefixLen;
- 	paramReq.ifr6_addr = address;
+    struct in6_ifreq paramReq;
+    memset(&paramReq, 0, sizeof(struct in6_ifreq));
+    paramReq.ifr6_ifindex = interfaceIndex;
+    paramReq.ifr6_prefixlen = prefixLen;
+    paramReq.ifr6_addr = address;
 
-	
+
     // Try add the address
-	if(ioctl(inet6, SIOCSIFADDR, &paramReq) < 0)
-	{
- 		printf
+    if(ioctl(inet6, SIOCSIFADDR, &paramReq) < 0)
+    {
+        printf
         (
             "There was an errror assigning address '%s/%d' to if_index %d\n",
             ip_str,
             prefixLen,
             interfaceIndex
         );
- 		cleanup();
- 		close(inet6);
- 		exit(1);
- 	}
+        cleanup();
+        close(inet6);
+        exit(1);
+    }
 
     printf("Address '%s/%d' added\n", ip_str, prefixLen);
-	close(inet6);
+    close(inet6);
 }
 
 int open_tap(void) {
@@ -260,9 +260,9 @@ int open_tap(void) {
                                         exit(1);
                                     }
 
-																		// if link-local was NOT requested and interface
-																		// has been up'd -> then kernel would have added
-																		// a link-local already, this removes it
+                                    // if link-local was NOT requested and interface
+                                    // has been up'd -> then kernel would have added
+                                    // a link-local already, this removes it
                                     if(!set_linklocal & !noup)
                                     {
                                     		// TODO: Get all addresses that start with fe80

--- a/TAP.c
+++ b/TAP.c
@@ -100,6 +100,7 @@ void trySixSet
         interfaceIndex
     );
 
+    // linux IPv6 mtu check
     if(mtu < 1280)
     {
         printf("MTU must be 1280 bytes or more for IPv6\n");
@@ -315,9 +316,8 @@ int open_tap(void) {
                                     }
                                 }
 
-                                if(set_ipv6 || link_local_v6) {
-                                	printf("TODO: Implement set ipv6\n");
-
+                                if(set_ipv6 || link_local_v6)
+                                {
                                     // Firstly, obtain the interface index by `ifr_name`
                                     int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
                                     if(ioctl(dummySock, SIOCGIFINDEX, &ifr) < 0)

--- a/TAP.c
+++ b/TAP.c
@@ -244,15 +244,6 @@ int open_tap(void) {
 
                                 if(set_ipv6 || link_local_v6)
                                 {
-                                    // linux IPv6 mtu check
-                                    if(mtu < 1280)
-                                    {
-                                        printf("MTU must be 1280 bytes or more for IPv6\n");
-                                        close(inet);
-                                        cleanup();
-                                        exit(1);
-                                    }
-
                                     // Firstly, obtain the interface index by `ifr_name`
                                     int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
                                     if(ioctl(inet6, SIOCGIFINDEX, &ifr) < 0)

--- a/TAP.c
+++ b/TAP.c
@@ -325,6 +325,16 @@ int open_tap(void) {
                                         exit(1);
                                     }
 
+                                    // Choose stratergy for generating link-local address
+                                    if(device_type == IF_TAP)                                
+                                    {
+
+                                    }
+                                    else
+                                    {
+                                        
+                                    }
+
                                     // Add link-local address
                                     trySixSet(ifr.ifr_ifindex, generateLinkLocal(if_name), 64);
 

--- a/TAP.c
+++ b/TAP.c
@@ -23,10 +23,22 @@ extern char* ipv6_addr;
 extern char* netmask;
 extern void cleanup();
 
+#include<stdlib.h>
+
+void localRand(struct in6_addr* ll_a)
+{
+    for(int i = 2; i < 16; i++)
+    {
+        ll_a->s6_addr[i] = rand();
+    }
+}
+
 // TODO: Allow optional-arg for case where we must also generate the hwaddr
 // (this would be the case whereby we are running without `--ethernet`)
 struct in6_addr generateLinkLocal(char* interfaceName)
 {
+    srand(0); // TODO: FIXME, use time or something
+
     struct in6_addr ll_a;
     memset(&ll_a, 0, sizeof(struct in6_addr));
     ll_a.s6_addr[0] = 0xfe;
@@ -38,6 +50,11 @@ struct in6_addr generateLinkLocal(char* interfaceName)
     // (TODO, should not matter, link-local is interface scoped)
     // TODO: Should tie it to mac address because of uniqueness
     // on the lan it shall attach to (over lora)
+    localRand(&ll_a);
+
+    
+
+
 
     int dummySock = socket(AF_PACKET, SOCK_PACKET, 0);
     if(dummySock < 0)
@@ -332,7 +349,7 @@ int open_tap(void) {
                                     }
                                     else
                                     {
-                                        
+
                                     }
 
                                     // Add link-local address

--- a/TAP.c
+++ b/TAP.c
@@ -60,50 +60,6 @@ struct in6_addr generateLinkLocal(char* interfaceName)
     return ll_a;
 }
 
-void trySixSet2(struct ifreq original, struct in6_addr address, int prefixLen)
-{
-	printf("Strat 2, running...\n");
-	
-
-	struct ifreq reqParam;
-	memset(&reqParam, 0, sizeof(struct ifreq));
-	strcpy(reqParam.ifr_name, original.ifr_name);
-	printf("interface name: (1) %s\n", reqParam.ifr_name);
-
-
-	int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
-	ioctl(dummySock, SIOCGIFINDEX, &reqParam);
-	printf("index: %d\n", reqParam.ifr_ifindex);
-	printf("interface name: (2) %s\n", reqParam.ifr_name);
-
-	struct sockaddr_in6 _6addr;
-	memset(&_6addr, 0, sizeof(struct sockaddr_in6));
-	_6addr.sin6_family = AF_INET6;
-	_6addr.sin6_addr = address;
-	struct sockaddr_in6* _6addrPtr = &_6addr;
-	reqParam.ifr_addr = *(struct sockaddr*)_6addrPtr;
-
-	// struct in6_ifreq _6reqParam;
-	// _6reqParam.ifr6_ifindex = reqParam.ifr_ifindex;
-	// _6reqParam.ifr6_prefixlen = prefixLen;
-	// _6reqParam.ifr6_addr = address;
-	
-	
-	printf("status after set: %d\n", ioctl(dummySock, SIOCSIFADDR, &_6addr));
-	printf("interface name: (3) %s\n", reqParam.ifr_name);
-
-// while(true){
-	ioctl(dummySock, SIOCGIFFLAGS, &reqParam);
-	printf("is Up?: %d\n", reqParam.ifr_flags&IFF_UP);
-	// }
-	
-
-	close(dummySock);
-
-	
-	exit(1);
-}
-
 #include <arpa/inet.h>
 
 void trySixSet

--- a/TAP.c
+++ b/TAP.c
@@ -29,7 +29,7 @@ void trySixSet
     char ip_str[INET6_ADDRSTRLEN+1];
     inet_ntop(AF_INET6, &address, ip_str, INET6_ADDRSTRLEN+1);
 
-	printf
+    printf
     (
         "Adding IPv6 address of '%s/%d' to interface at if_index %d\n",
         ip_str,

--- a/TAP.c
+++ b/TAP.c
@@ -33,11 +33,14 @@ void localRand(struct in6_addr* ll_a)
     }
 }
 
+#include<time.h>
+
 // TODO: Allow optional-arg for case where we must also generate the hwaddr
 // (this would be the case whereby we are running without `--ethernet`)
 struct in6_addr generateLinkLocal(char* interfaceName)
 {
-    srand(0); // TODO: FIXME, use time or something
+    time_t t = time(NULL);
+    srand(t); // TODO: FIXME, use time or something
 
     struct in6_addr ll_a;
     memset(&ll_a, 0, sizeof(struct in6_addr));

--- a/TAP.c
+++ b/TAP.c
@@ -95,13 +95,7 @@ int open_tap(void) {
             strcpy(if_name, ifr.ifr_name);
 
             
-            int inet = socket(set_ipv4 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);
-            printf("inet fd: %d\n", inet);
-            printf("tun/tap handle fd: %d\n", fd);
-            printf("set_ipv4: %d\n", set_ipv4);
-            printf("set_ipv6: %d\n", set_ipv6);
-            
-            // inet=fd;
+            int inet = socket(AF_INET, SOCK_DGRAM, 0);
             if (inet == -1) {
             	  char err[100];
             		sprintf(err, "Could not open %s socket", set_ipv4 ? "AF_INET" : "AF_INET6");

--- a/TAP.c
+++ b/TAP.c
@@ -1,11 +1,11 @@
 #include "TAP.h"
 
 // Needed for in6_ifreq
-#include <arpa/inet.h>
+// #include <arpa/inet.h>
 #include <linux/ipv6.h>
-#include <netinet/in.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
+// #include <netinet/in.h>
+// #include <sys/ioctl.h>
+// #include <sys/socket.h>
 
 char tap_name[IFNAMSIZ];
 
@@ -43,7 +43,7 @@ void trySixSet
         interfaceIndex
     );
 
-	int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
+	int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
 
 	struct in6_ifreq paramReq;
 	memset(&paramReq, 0, sizeof(struct in6_ifreq));
@@ -53,7 +53,7 @@ void trySixSet
 
 	
     // Try add the address
-	if(ioctl(dummySock, SIOCSIFADDR, &paramReq) < 0)
+	if(ioctl(inet6, SIOCSIFADDR, &paramReq) < 0)
 	{
  		printf
         (
@@ -63,12 +63,12 @@ void trySixSet
             interfaceIndex
         );
  		cleanup();
- 		close(dummySock);
+ 		close(inet6);
  		exit(1);
  	}
 
     printf("Address '%s/%d' added\n", ip_str, prefixLen);
-	close(dummySock);
+	close(inet6);
 }
 
 #include<string.h>
@@ -257,16 +257,17 @@ int open_tap(void) {
                                     if(mtu < 1280)
                                     {
                                         printf("MTU must be 1280 bytes or more for IPv6\n");
+                                        close(inet);
                                         cleanup();
                                         exit(1);
                                     }
 
                                     // Firstly, obtain the interface index by `ifr_name`
-                                    int dummySock = socket(AF_INET6, SOCK_DGRAM, 0);
-                                    if(ioctl(dummySock, SIOCGIFINDEX, &ifr) < 0)
+                                    int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
+                                    if(ioctl(inet6, SIOCGIFINDEX, &ifr) < 0)
                                     {
                                         printf("Could not get interface index for interface '%s'\n", ifr.ifr_name);
-                                        close(dummySock);
+                                        close(inet6);
                                         cleanup();
                                         exit(1);
                                     }
@@ -287,7 +288,7 @@ int open_tap(void) {
                                         if(!prefixPart_s)
                                         {
                                             perror("No prefix length was provided"); // TODO: Move logic into arg parsing
-                                            close(dummySock);
+                                            close(inet6);
                                             cleanup();
                                             exit(1);
                                         }
@@ -303,7 +304,7 @@ int open_tap(void) {
                                         if(inet_pton(AF_INET6, ipv6_addr, &six_addr_itself) < 0)
                                         {
                                             printf("Error parsing IPv6 address '%s'\n", ipv6_addr);
-                                            close(dummySock);
+                                            close(inet6);
                                             cleanup();
                                             exit(1);
                                         }

--- a/TAP.c
+++ b/TAP.c
@@ -24,63 +24,6 @@ extern char* ipv6_addr;
 extern char* netmask;
 extern void cleanup();
 
-#include<stdlib.h>
-
-void localRand(struct in6_addr* ll_a)
-{
-    for(int i = 2; i < 16; i++)
-    {
-        ll_a->s6_addr[i] = rand();
-    }
-}
-
-#include<time.h>
-
-// TODO: Allow optional-arg for case where we must also generate the hwaddr
-// (this would be the case whereby we are running without `--ethernet`)
-struct in6_addr generateLinkLocal(char* interfaceName)
-{
-    time_t t = time(NULL);
-    srand(t);
-
-    struct in6_addr ll_a;
-    memset(&ll_a, 0, sizeof(struct in6_addr));
-    ll_a.s6_addr[0] = 0xfe;
-    ll_a.s6_addr[1] = 0x80;
-
-    // TODO: Set the rest here
-
-    // TODO: Loop till we generate an address NOT in use
-    // (TODO, should not matter, link-local is interface scoped)
-    // TODO: Should tie it to mac address because of uniqueness
-    // on the lan it shall attach to (over lora)
-    localRand(&ll_a);
-
-    
-
-
-
-    int dummySock = socket(AF_PACKET, SOCK_PACKET, 0);
-    if(dummySock < 0)
-    {
-        printf("Failed to open configuration socket in order to generate link-local address\n");
-        close(dummySock);
-        exit(1);
-    }
-
-    struct ifreq reqParams;
-    memset(&reqParams, 0, sizeof(reqParams));
-    strcpy(reqParams.ifr_name, interfaceName);
-
-    if(ioctl(dummySock, SIOCGIFHWADDR, &reqParams) < 0)
-    {
-        printf("Failed to fetch hardware address Failed to open configuration socket in order to generate link-local address\n");
-        close(dummySock);
-        exit(1);
-    }
-
-    return ll_a;
-}
 
 void trySixSet
 (
@@ -164,8 +107,8 @@ int open_tap(void) {
             int inet = socket(set_ipv4 ? AF_INET : AF_INET6, SOCK_DGRAM, 0);
             printf("inet fd: %d\n", inet);
             printf("tun/tap handle fd: %d\n", fd);
-						printf("set_ipv4: %d\n", set_ipv4);
-						printf("set_ipv6: %d\n", set_ipv6);
+            printf("set_ipv4: %d\n", set_ipv4);
+            printf("set_ipv6: %d\n", set_ipv6);
             
             // inet=fd;
             if (inet == -1) {
@@ -331,8 +274,7 @@ int open_tap(void) {
                                     // If link-local was requested
                                     if(link_local_v6)
                                     {
-                                        // Add link-local address
-                                        trySixSet(ifr.ifr_ifindex, generateLinkLocal(if_name), 64);
+                                        // Do nothing; kernel adds for us
                                     }
 
                                     // If use-specified non-link-local IPv6 was 

--- a/TAP.c
+++ b/TAP.c
@@ -284,6 +284,8 @@ int open_tap(void) {
 
                                     // Add user's requested address
                                     trySixSet(ifr.ifr_ifindex, six_addr_itself, prefixLen_l);
+
+                                    close(inet6);
                                 }
                             }
                         }

--- a/TAP.c
+++ b/TAP.c
@@ -244,6 +244,13 @@ int open_tap(void) {
                                 {
                                     // Firstly, obtain the interface index by `ifr_name`
                                     int inet6 = socket(AF_INET6, SOCK_DGRAM, 0);
+                                    if(inet6 < 0)
+                                    {
+                                        printf("Error opening control socket for adding IPv6 address to interface\n");
+                                        cleanup();
+                                        exit(1);
+                                    }
+
                                     if(ioctl(inet6, SIOCGIFINDEX, &ifr) < 0)
                                     {
                                         printf("Could not get interface index for interface '%s'\n", ifr.ifr_name);

--- a/TAP.c
+++ b/TAP.c
@@ -1,8 +1,7 @@
 #include "TAP.h"
 
 // Needed for in6_ifreq
-// #include <cstdio>
-// #include <cstdlib>
+#include <arpa/inet.h>
 #include <linux/ipv6.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>
@@ -59,8 +58,6 @@ struct in6_addr generateLinkLocal(char* interfaceName)
 
     return ll_a;
 }
-
-#include <arpa/inet.h>
 
 void trySixSet
 (

--- a/TAP.c
+++ b/TAP.c
@@ -326,56 +326,59 @@ int open_tap(void) {
                                         close(dummySock);
                                         cleanup();
                                         exit(1);
-                                    }					
-
-                                    
-                                    char* ipPart = strtok(ipv6_addr, "/");
-                                    char* prefixPart_s = strtok(NULL, "/");
-                                    printf("ip part: %s\n", ipPart);
-
-                                    if(!prefixPart_s)
-                                    {
-                                        perror("No prefix length was provided"); // TODO: Move logic into arg parsing
-                                        close(dummySock);
-                                        cleanup();
-                                        exit(1);
-                                    }
-                                    printf("prefix part: %s\n", prefixPart_s);
-
-                                    long prefixLen_l = strtol(prefixPart_s, NULL, 10); // TODO: Add handling here for errors (using errno)
-
-
-
-                                    // Convert ASCII IPv6 address to ABI structure
-                                    struct in6_addr six_addr_itself;
-                                    memset(&six_addr_itself, 0, sizeof(struct in6_addr));
-                                    if(inet_pton(AF_INET6, ipv6_addr, &six_addr_itself) < 0)
-                                    {
-                                        printf("Error parsing IPv6 address '%s'\n", ipv6_addr);
-                                        close(dummySock);
-                                        cleanup();
-                                        exit(1);
                                     }
 
-                                    // Choose stratergy for generating link-local address
-                                    if(device_type == IF_TAP)                                
+                                    // If link-local was requested
+                                    if(link_local_v6)
                                     {
-
-                                    }
-                                    else
-                                    {
-
+                                        // Add link-local address
+                                        trySixSet(ifr.ifr_ifindex, generateLinkLocal(if_name), 64);
                                     }
 
-                                    // Add link-local address
-                                    trySixSet(ifr.ifr_ifindex, generateLinkLocal(if_name), 64);
+                                    // If use-specified non-link-local IPv6 was 
+                                    if(set_ipv6)
+                                    {
+                                        char* ipPart = strtok(ipv6_addr, "/");
+                                        char* prefixPart_s = strtok(NULL, "/");
+                                        printf("ip part: %s\n", ipPart);
 
-                                    // Add user's requested address
-                                    trySixSet(ifr.ifr_ifindex, six_addr_itself, prefixLen_l);
+                                        if(!prefixPart_s)
+                                        {
+                                            perror("No prefix length was provided"); // TODO: Move logic into arg parsing
+                                            close(dummySock);
+                                            cleanup();
+                                            exit(1);
+                                        }
+                                        printf("prefix part: %s\n", prefixPart_s);
 
-                                    // FIXME: Allow the ipv6 to be empty and just do link-local
+                                        long prefixLen_l = strtol(prefixPart_s, NULL, 10); // TODO: Add handling here for errors (using errno)
 
-                                    printf("IPv6 configuration done\n");
+
+
+                                        // Convert ASCII IPv6 address to ABI structure
+                                        struct in6_addr six_addr_itself;
+                                        memset(&six_addr_itself, 0, sizeof(struct in6_addr));
+                                        if(inet_pton(AF_INET6, ipv6_addr, &six_addr_itself) < 0)
+                                        {
+                                            printf("Error parsing IPv6 address '%s'\n", ipv6_addr);
+                                            close(dummySock);
+                                            cleanup();
+                                            exit(1);
+                                        }
+
+                                        // Choose stratergy for generating link-local address
+                                        if(device_type == IF_TAP)                                
+                                        {
+
+                                        }
+                                        else
+                                        {
+
+                                        }
+                                        
+                                        // Add user's requested address
+                                        trySixSet(ifr.ifr_ifindex, six_addr_itself, prefixLen_l);
+                                    }
                                 }
                             }
                         }

--- a/TAP.h
+++ b/TAP.h
@@ -9,6 +9,7 @@
 #include <linux/if_tun.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>
+#include <linux/ipv6.h>
 #include "Constants.h"
 
 int open_tap(void);

--- a/tncattach.c
+++ b/tncattach.c
@@ -35,6 +35,7 @@ bool noup = false;
 bool daemonize = false;
 bool set_ipv4 = false;
 bool set_ipv6 = false;
+bool link_local_v6 = false; // FIXME: make this true by default
 bool set_netmask = false;
 bool kiss_over_tcp = false;
 char* ipv4_addr;
@@ -273,15 +274,16 @@ static struct argp_option options[] = {
     { "ethernet", 'e', 0, 0, "Create a full ethernet device", 2},
     { "ipv4", 'i', "IP_ADDRESS", 0, "Configure an IPv4 address on interface", 3},
     { "ipv6", '6', "IP6_ADDRESS", 0, "Configure an IPv6 address on interface", 4},
-    { "noipv6", 'n', 0, 0, "Filter IPv6 traffic from reaching TNC", 5},
-    { "noup", 1, 0, 0, "Only create interface, don't bring it up", 6},
-    { "kisstcp", 'T', 0, 0, "Use KISS over TCP instead of serial port", 7},
-    { "tcphost", 'H', "TCP_HOST", 0, "Host to connect to when using KISS over TCP", 8},
-    { "tcpport", 'P', "TCP_PORT", 0, "TCP port when using KISS over TCP", 9},
-    { "interval", 't', "SECONDS", 0, "Maximum interval between station identifications", 10},
-    { "id", 's', "CALLSIGN", 0, "Station identification data", 11},
-    { "daemon", 'd', 0, 0, "Run tncattach as a daemon", 12},
-    { "verbose", 'v', 0, 0, "Enable verbose output", 13},
+    { "ll", 'l', 0, 0, "Add a link-local Ipv6 address", 5},
+    { "noipv6", 'n', 0, 0, "Filter IPv6 traffic from reaching TNC", 6},
+    { "noup", 1, 0, 0, "Only create interface, don't bring it up", 7},
+    { "kisstcp", 'T', 0, 0, "Use KISS over TCP instead of serial port", 8},
+    { "tcphost", 'H', "TCP_HOST", 0, "Host to connect to when using KISS over TCP", 9},
+    { "tcpport", 'P', "TCP_PORT", 0, "TCP port when using KISS over TCP", 10},
+    { "interval", 't', "SECONDS", 0, "Maximum interval between station identifications", 11},
+    { "id", 's', "CALLSIGN", 0, "Station identification data", 12},
+    { "daemon", 'd', 0, 0, "Run tncattach as a daemon", 13},
+    { "verbose", 'v', 0, 0, "Enable verbose output", 14},
     { 0 }
 };
 
@@ -302,6 +304,7 @@ struct arguments {
     bool set_ipv4;
     bool set_netmask;
     bool set_ipv6;
+    bool link_local_v6;
     bool set_netmask_v6;
     bool noipv6;
     bool noup;
@@ -487,6 +490,15 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             strcpy(ipv6_addr, arguments->ipv6);
             printf("v6 now: %s\n", ipv6_addr);
             break;
+
+        case 'l':
+            if(arguments->noipv6)
+            {
+                perror("Sorry, but you had noipv6 set yet want to use ipv6 link-local?\n");
+                exit(EXIT_FAILURE);
+            }
+            arguments->link_local_v6 = true;
+            break;
 						
         case 'n':
             arguments->noipv6 = true;
@@ -586,6 +598,7 @@ int main(int argc, char **argv) {
     arguments.set_ipv4 = false;
     arguments.set_netmask = false;
     arguments.set_ipv6 = false;
+    arguments.link_local_v6 = false;
     arguments.set_netmask_v6 = false;
     arguments.noipv6 = false;
     arguments.daemon = false;
@@ -615,6 +628,7 @@ int main(int argc, char **argv) {
     if (arguments.set_ipv4) set_ipv4 = true;
     if (arguments.set_netmask) set_netmask = true;
     if (arguments.set_ipv6) set_ipv6 = true;
+    if (arguments.link_local_v6) link_local_v6 = true;
     if (arguments.noup) noup = true;
     mtu = arguments.mtu;
 

--- a/tncattach.c
+++ b/tncattach.c
@@ -494,7 +494,6 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             // Save to the global for other modules to access it
             ipv6_addr = malloc(strlen(arguments->ipv6)+1);
             strcpy(ipv6_addr, arguments->ipv6);
-            printf("v6 now: %s\n", ipv6_addr);
 
             printf("MTU was %d, setting to minimum of %d as is required for IPv6\n", arguments->mtu, 1280);
             arguments->mtu = 1280;

--- a/tncattach.c
+++ b/tncattach.c
@@ -331,6 +331,13 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                 printf("Error: Invalid MTU specified\r\n\r\n");
                 argp_usage(state);
             }
+
+            if(arguments->set_ipv6 || arguments->link_local_v6)
+            {
+                printf("IPv6 and/or link-loal IPv6 was requested, but the MTU provided is lower than 1280\n");
+                exit(EXIT_FAILURE);
+            }
+
             break;
 
         case 't':
@@ -489,6 +496,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             ipv6_addr = malloc(strlen(arguments->ipv6)+1);
             strcpy(ipv6_addr, arguments->ipv6);
             printf("v6 now: %s\n", ipv6_addr);
+
+            printf("MTU was %d, setting to minimum of %d as is required for IPv6\n", arguments->mtu, 1280);
+            arguments->mtu = 1280;
             break;
 
         case 'l':
@@ -498,6 +508,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                 exit(EXIT_FAILURE);
             }
             arguments->link_local_v6 = true;
+
+            printf("MTU was %d, setting to minimum of %d as is required for IPv6\n", arguments->mtu, 1280);
+            arguments->mtu = 1280;
             break;
 						
         case 'n':

--- a/tncattach.c
+++ b/tncattach.c
@@ -332,7 +332,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                 argp_usage(state);
             }
 
-            if(arguments->set_ipv6 || arguments->link_local_v6)
+            if((arguments->set_ipv6 || arguments->link_local_v6) && arguments->mtu < 1280)
             {
                 printf("IPv6 and/or link-loal IPv6 was requested, but the MTU provided is lower than 1280\n");
                 exit(EXIT_FAILURE);

--- a/tncattach.c
+++ b/tncattach.c
@@ -35,6 +35,7 @@ bool noup = false;
 bool daemonize = false;
 bool set_ipv4 = false;
 bool set_ipv6 = false;
+bool set_linklocal = false;
 bool set_netmask = false;
 bool kiss_over_tcp = false;
 char* ipv4_addr;

--- a/tncattach.c
+++ b/tncattach.c
@@ -504,6 +504,10 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
             long prefixLen_l = strtol(prefixPart_s, NULL, 10); // TODO: Add handling here for errors (using errno)
 
+						if(prefixLen_l == 0) {
+								printf("Prefix length '%s' is not numeric\n", prefixPart_s);
+								exit(EXIT_FAILURE);
+						}
 
             arguments->ipv6 = ipPart_s;
             

--- a/tncattach.c
+++ b/tncattach.c
@@ -508,6 +508,11 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 								printf("Prefix length '%s' is not numeric\n", prefixPart_s);
 								exit(EXIT_FAILURE);
 						}
+						else if(!(prefixLen_l >= 0 && prefixLen_l <= 128))
+						{
+								printf("Prefix length '%s' is not within valid range of 0-128\n", prefixPart_s);
+								exit(EXIT_FAILURE);
+						}
 
             arguments->ipv6 = ipPart_s;
             

--- a/tncattach.c
+++ b/tncattach.c
@@ -35,7 +35,6 @@ bool noup = false;
 bool daemonize = false;
 bool set_ipv4 = false;
 bool set_ipv6 = false;
-bool link_local_v6 = false; // FIXME: make this true by default
 bool set_netmask = false;
 bool kiss_over_tcp = false;
 char* ipv4_addr;
@@ -641,7 +640,6 @@ int main(int argc, char **argv) {
     if (arguments.set_ipv4) set_ipv4 = true;
     if (arguments.set_netmask) set_netmask = true;
     if (arguments.set_ipv6) set_ipv6 = true;
-    if (arguments.link_local_v6) link_local_v6 = true;
     if (arguments.noup) noup = true;
     mtu = arguments.mtu;
 

--- a/tncattach.c
+++ b/tncattach.c
@@ -504,15 +504,15 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
             long prefixLen_l = strtol(prefixPart_s, NULL, 10); // TODO: Add handling here for errors (using errno)
 
-						if(prefixLen_l == 0) {
-								printf("Prefix length '%s' is not numeric\n", prefixPart_s);
-								exit(EXIT_FAILURE);
-						}
-						else if(!(prefixLen_l >= 0 && prefixLen_l <= 128))
-						{
-								printf("Prefix length '%s' is not within valid range of 0-128\n", prefixPart_s);
-								exit(EXIT_FAILURE);
-						}
+            if(prefixLen_l == 0) {
+                printf("Prefix length '%s' is not numeric\n", prefixPart_s);
+                exit(EXIT_FAILURE);
+            }
+            else if(!(prefixLen_l >= 0 && prefixLen_l <= 128))
+            {
+                printf("Prefix length '%s' is not within valid range of 0-128\n", prefixPart_s);
+                exit(EXIT_FAILURE);
+            }
 
             arguments->ipv6 = ipPart_s;
             
@@ -540,7 +540,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
             printf("MTU was %d, setting to minimum of %d as is required for IPv6\n", arguments->mtu, 1280);
             arguments->mtu = 1280;
             break;
-						
+
         case 'n':
             arguments->noipv6 = true;
             if(arguments->set_ipv6)

--- a/tncattach.c
+++ b/tncattach.c
@@ -41,6 +41,7 @@ char* ipv4_addr;
 char* netmask;
 
 char* ipv6_addr;
+long ipv6_prefixLen;
 
 char* tcp_host;
 int tcp_port;
@@ -488,12 +489,31 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
                 perror("Sorry, but you had noipv6 set yet want to use ipv6?\n");
                 exit(EXIT_FAILURE);
             }
-            arguments->ipv6 = arg;
+
+            char* ipPart_s = strtok(arg, "/");
+            char* prefixPart_s = strtok(NULL, "/");
+            printf("ipPart_s: %s\n", ipPart_s);
+
+            if(!prefixPart_s)
+            {
+                printf("No prefix length was provided\n");
+                exit(1);
+            }
+            printf("prefixPart_s: %s\n", prefixPart_s);
+
+            long prefixLen_l = strtol(prefixPart_s, NULL, 10); // TODO: Add handling here for errors (using errno)
+
+
+            arguments->ipv6 = ipPart_s;
+            
             arguments->set_ipv6 = true;
 
-            // Save to the global for other modules to access it
+            // Copy across global IPv6 address
             ipv6_addr = malloc(strlen(arguments->ipv6)+1);
             strcpy(ipv6_addr, arguments->ipv6);
+
+            // Set global IPv6 prefix length
+            ipv6_prefixLen = prefixLen_l;
 
             printf("MTU was %d, setting to minimum of %d as is required for IPv6\n", arguments->mtu, 1280);
             arguments->mtu = 1280;

--- a/tncattach.c
+++ b/tncattach.c
@@ -334,7 +334,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 
             if((arguments->set_ipv6 || arguments->link_local_v6) && arguments->mtu < 1280)
             {
-                printf("IPv6 and/or link-loal IPv6 was requested, but the MTU provided is lower than 1280\n");
+                printf("IPv6 and/or link-local IPv6 was requested, but the MTU provided is lower than 1280\n");
                 exit(EXIT_FAILURE);
             }
 

--- a/tncattach.c
+++ b/tncattach.c
@@ -41,7 +41,6 @@ char* ipv4_addr;
 char* netmask;
 
 char* ipv6_addr;
-char* netmask_v6;
 
 char* tcp_host;
 int tcp_port;


### PR DESCRIPTION
## Purpose :writing_hand: 

Add IPv6 support.

### Issues

- [x] tuntap refuses (even tested with `ip addr add <v6addr> dev tnc0` to accept IPv6 addresses
- [x] command-line parsing
- [x] driver code (tuntap)
- [x] code review // clean up // safety checks // error handling